### PR TITLE
Added getter/setter for current index position

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ const RovingTabindex = require('makeup-roving-tabindex');
 const widgetEl = document.querySelector('.widget');
 
 // create a roving tabindex instance on the element
-const rovingTabindex = RovingTabindex.createLinear(widgetEl, 'li', { autoReset: null, index: 0 });
+const rovingTabindex = RovingTabindex.createLinear(widgetEl, 'li');
 
 // listen for events (optional)
 widgetEl.addEventListener('rovingTabindexChange', function(e) {
@@ -69,9 +69,17 @@ Markup after:
 
 ## Options
 
-* `autoReset`: specify an index value that should receive tabindex="0" on navigationModelReset event (default: null)
-* `index`: the index position of the active item (default: 0)
+* `autoReset`: the index position that should receive the roving tabindex when model is reset (default: null)
+* `index`: the initial index position of the roving tabindex (default: 0)
 * `wrap` : specify whether arrow keys should wrap/loop (default: false)
+
+## Properties
+
+* `index`: the index position of the roving tabindex (i.e. the element with tabindex="0")
+
+## Methods
+
+* `destroy`: destroys all event listeners
 
 ## Custom Events        
 

--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -4,6 +4,7 @@
     "browser": true
   },
   "rules": {
-    "no-console": 0
+    "no-console": 0,
+    "no-param-reassign": 0
   }
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,8 +21,10 @@
 
             <fieldset>
                 <legend>Tools</legend>
-                <button id="appender">Append New Items</button>
-                <label>Wrap</label><input id="wrap" type="checkbox">
+                <button id="decrementer" type="button">Decrement tabindex</button>
+                <button id="incrementer" type="button">Increment tabindex</button>
+                <button id="appender" type="button">Append New Items</button>
+                <label for="wrap">Wrap</label><input id="wrap" type="checkbox">
             </fieldset>
         </main>
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -4,9 +4,16 @@ function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
 }
 
+function querySelectorAllToArray(selector, parentNode) {
+    parentNode = parentNode || document;
+    return nodeListToArray(parentNode.querySelectorAll(selector));
+}
+
 var rovers = [];
 var appender = document.getElementById('appender');
-var widgetEls = nodeListToArray(document.querySelectorAll('.widget'));
+var incrementer = document.getElementById('incrementer');
+var decrementer = document.getElementById('decrementer');
+var widgetEls = querySelectorAllToArray('.widget');
 var wrapCheckbox = document.getElementById('wrap');
 
 appender.addEventListener('click', function() {
@@ -14,6 +21,18 @@ appender.addEventListener('click', function() {
         var listItem = document.createElement('li');
         listItem.innerText = 'Item ' + parseInt(el.querySelectorAll('li').length, 10);
         el.children[0].appendChild(listItem);
+    });
+});
+
+incrementer.addEventListener('click', function() {
+    widgetEls.forEach(function(el, i) {
+        rovers[i].index++;
+    });
+});
+
+decrementer.addEventListener('click', function() {
+    widgetEls.forEach(function(el, i) {
+        rovers[i].index--;
     });
 });
 

--- a/index.js
+++ b/index.js
@@ -23,37 +23,41 @@ function onModelMutation() {
     var modelIndex = this._navigationEmitter.model.index;
 
     this._items.forEach(function (el, index) {
-        if (index !== modelIndex) {
-            el.setAttribute('tabindex', '-1');
-        } else {
-            el.setAttribute('tabindex', '0');
-        }
+        return el.setAttribute('tabindex', index !== modelIndex ? '-1' : '0');
     });
 }
 
 function onModelInit(e) {
-    this._index = e.detail.toIndex;
+    this._index = e.detail.toIndex; // seems unused internally. scheduled for deletion.
 
-    this._items.forEach(function (el) {
-        el.setAttribute('tabindex', '-1');
+    var items = this._items;
+
+    items.filter(function (el, index) {
+        return index !== e.detail.toIndex;
+    }).forEach(function (el) {
+        return el.setAttribute('tabindex', '-1');
     });
-
-    this._items[e.detail.toIndex].setAttribute('tabindex', '0');
+    items[e.detail.toIndex].setAttribute('tabindex', '0');
 }
 
 function onModelReset(e) {
-    this._index = e.detail.toIndex;
+    this._index = e.detail.toIndex; // seems unused internally. scheduled for deletion.
 
-    this._items.forEach(function (el) {
-        el.setAttribute('tabindex', '-1');
+    var items = this._items;
+
+    items.filter(function (el, index) {
+        return index !== e.detail.toIndex;
+    }).forEach(function (el) {
+        return el.setAttribute('tabindex', '-1');
     });
-
-    this._items[e.detail.toIndex].setAttribute('tabindex', '0');
+    items[e.detail.toIndex].setAttribute('tabindex', '0');
 }
 
 function onModelChange(e) {
-    var fromItem = this._items[e.detail.fromIndex];
-    var toItem = this._items[e.detail.toIndex];
+    var items = this._items;
+
+    var fromItem = items[e.detail.fromIndex];
+    var toItem = items[e.detail.toIndex];
 
     if (fromItem) {
         fromItem.setAttribute('tabindex', '-1');
@@ -66,8 +70,8 @@ function onModelChange(e) {
 
     this._el.dispatchEvent(new CustomEvent('rovingTabindexChange', {
         detail: {
-            toIndex: e.detail.toIndex,
-            fromIndex: e.detail.fromIndex
+            fromIndex: e.detail.fromIndex,
+            toIndex: e.detail.toIndex
         }
     }));
 }
@@ -127,6 +131,14 @@ var LinearRovingTabindex = function (_RovingTabindex) {
             this._navigationEmitter.destroy();
         }
     }, {
+        key: 'index',
+        get: function get() {
+            return this._navigationEmitter.model.index;
+        },
+        set: function set(newIndex) {
+            this._navigationEmitter.model.index = newIndex;
+        }
+    }, {
         key: 'wrap',
         set: function set(newWrap) {
             this._navigationEmitter.model.options.wrap = newWrap;
@@ -137,7 +149,7 @@ var LinearRovingTabindex = function (_RovingTabindex) {
     }, {
         key: '_items',
         get: function get() {
-            return Util.nodeListToArray(this._el.querySelectorAll(this._itemSelector));
+            return Util.querySelectorAllToArray(this._itemSelector, this._el);
         }
     }]);
 
@@ -146,7 +158,7 @@ var LinearRovingTabindex = function (_RovingTabindex) {
 
 /*
 class GridRovingTabindex extends RovingTabindex {
-    constructor(el, rowSelector, cellSelector) {
+    constructor(el, rowSelector, cellSelector, selectedOptions) {
         super(el);
     }
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "rimraf": "^2"
   },
   "dependencies": {
-    "makeup-navigation-emitter": "~0.1.3"
+    "makeup-navigation-emitter": "~0.1.4"
   },
   "files": [
     "browser.json",

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -4,6 +4,7 @@
       "browser": true
   },
   "rules": {
-    "prefer-arrow-callback": 0
+    "prefer-arrow-callback": 0,
+    "no-param-reassign": 0
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,38 +12,32 @@ const defaultOptions = {
 function onModelMutation() {
     const modelIndex = this._navigationEmitter.model.index;
 
-    this._items.forEach(function(el, index) {
-        if (index !== modelIndex) {
-            el.setAttribute('tabindex', '-1');
-        } else {
-            el.setAttribute('tabindex', '0');
-        }
-    });
+    this._items.forEach((el, index) => el.setAttribute('tabindex', index !== modelIndex ? '-1' : '0'));
 }
 
 function onModelInit(e) {
-    this._index = e.detail.toIndex;
+    this._index = e.detail.toIndex; // seems unused internally. scheduled for deletion.
 
-    this._items.forEach(function(el) {
-        el.setAttribute('tabindex', '-1');
-    });
+    const items = this._items;
 
-    this._items[e.detail.toIndex].setAttribute('tabindex', '0');
+    items.filter((el, index) => index !== e.detail.toIndex).forEach(el => el.setAttribute('tabindex', '-1'));
+    items[e.detail.toIndex].setAttribute('tabindex', '0');
 }
 
 function onModelReset(e) {
-    this._index = e.detail.toIndex;
+    this._index = e.detail.toIndex; // seems unused internally. scheduled for deletion.
 
-    this._items.forEach(function(el) {
-        el.setAttribute('tabindex', '-1');
-    });
+    const items = this._items;
 
-    this._items[e.detail.toIndex].setAttribute('tabindex', '0');
+    items.filter((el, index) => index !== e.detail.toIndex).forEach(el => el.setAttribute('tabindex', '-1'));
+    items[e.detail.toIndex].setAttribute('tabindex', '0');
 }
 
 function onModelChange(e) {
-    const fromItem = this._items[e.detail.fromIndex];
-    const toItem = this._items[e.detail.toIndex];
+    const items = this._items;
+
+    const fromItem = items[e.detail.fromIndex];
+    const toItem = items[e.detail.toIndex];
 
     if (fromItem) {
         fromItem.setAttribute('tabindex', '-1');
@@ -56,8 +50,8 @@ function onModelChange(e) {
 
     this._el.dispatchEvent(new CustomEvent('rovingTabindexChange', {
         detail: {
-            toIndex: e.detail.toIndex,
-            fromIndex: e.detail.fromIndex
+            fromIndex: e.detail.fromIndex,
+            toIndex: e.detail.toIndex
         }
     }));
 }
@@ -99,13 +93,21 @@ class LinearRovingTabindex extends RovingTabindex {
         });
     }
 
+    get index() {
+        return this._navigationEmitter.model.index;
+    }
+
+    set index(newIndex) {
+        this._navigationEmitter.model.index = newIndex;
+    }
+
     set wrap(newWrap) {
         this._navigationEmitter.model.options.wrap = newWrap;
     }
 
     // we cannot use a cached version of the items in question since the DOM may change without notice
     get _items() {
-        return Util.nodeListToArray(this._el.querySelectorAll(this._itemSelector));
+        return Util.querySelectorAllToArray(this._itemSelector, this._el);
     }
 
     destroy() {
@@ -115,7 +117,7 @@ class LinearRovingTabindex extends RovingTabindex {
 
 /*
 class GridRovingTabindex extends RovingTabindex {
-    constructor(el, rowSelector, cellSelector) {
+    constructor(el, rowSelector, cellSelector, selectedOptions) {
         super(el);
     }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -2,6 +2,12 @@ function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
 }
 
+function querySelectorAllToArray(selector, parentNode) {
+    parentNode = parentNode || document;
+    return nodeListToArray(parentNode.querySelectorAll(selector));
+}
+
+
 module.exports = {
-    nodeListToArray
+    querySelectorAllToArray
 };

--- a/test/static/bundle-module.js
+++ b/test/static/bundle-module.js
@@ -1,6 +1,6 @@
-$_mod.installed("makeup-roving-tabindex$0.1.2", "makeup-navigation-emitter", "0.1.3");
-$_mod.main("/makeup-navigation-emitter$0.1.3", "");
-$_mod.installed("makeup-navigation-emitter$0.1.3", "custom-event-polyfill", "1.0.7");
+$_mod.installed("makeup-roving-tabindex$0.1.2", "makeup-navigation-emitter", "0.1.4");
+$_mod.main("/makeup-navigation-emitter$0.1.4", "");
+$_mod.installed("makeup-navigation-emitter$0.1.4", "custom-event-polyfill", "1.0.7");
 $_mod.main("/custom-event-polyfill$1.0.7", "polyfill");
 $_mod.def("/custom-event-polyfill$1.0.7/polyfill", function(require, exports, module, __filename, __dirname) { // Polyfill for creating CustomEvents on IE9/10/11
 
@@ -57,7 +57,7 @@ $_mod.def("/custom-event-polyfill$1.0.7/polyfill", function(require, exports, mo
 })();
 
 });
-$_mod.def("/makeup-navigation-emitter$0.1.3/util", function(require, exports, module, __filename, __dirname) { "use strict";
+$_mod.def("/makeup-navigation-emitter$0.1.4/util", function(require, exports, module, __filename, __dirname) { "use strict";
 
 function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
@@ -68,7 +68,7 @@ module.exports = {
 };
 
 });
-$_mod.installed("makeup-navigation-emitter$0.1.3", "makeup-key-emitter", "0.0.3");
+$_mod.installed("makeup-navigation-emitter$0.1.4", "makeup-key-emitter", "0.0.3");
 $_mod.main("/makeup-key-emitter$0.0.3", "");
 $_mod.installed("makeup-key-emitter$0.0.3", "custom-event-polyfill", "0.3.0");
 $_mod.main("/custom-event-polyfill$0.3.0", "custom-event-polyfill");
@@ -227,7 +227,7 @@ module.exports = {
 };
 
 });
-$_mod.installed("makeup-navigation-emitter$0.1.3", "makeup-exit-emitter", "0.0.4");
+$_mod.installed("makeup-navigation-emitter$0.1.4", "makeup-exit-emitter", "0.0.4");
 $_mod.main("/makeup-exit-emitter$0.0.4", "");
 $_mod.installed("makeup-exit-emitter$0.0.4", "custom-event-polyfill", "0.3.0");
 $_mod.installed("makeup-exit-emitter$0.0.4", "makeup-next-id", "0.0.2");
@@ -355,7 +355,7 @@ module.exports = {
 };
 
 });
-$_mod.def("/makeup-navigation-emitter$0.1.3/index", function(require, exports, module, __filename, __dirname) { 'use strict';
+$_mod.def("/makeup-navigation-emitter$0.1.4/index", function(require, exports, module, __filename, __dirname) { 'use strict';
 
 // requires Object.assign polyfill or transform for IE
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Polyfill
@@ -370,7 +370,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var Util = require('/makeup-navigation-emitter$0.1.3/util'/*'./util.js'*/);
+var Util = require('/makeup-navigation-emitter$0.1.4/util'/*'./util.js'*/);
 var KeyEmitter = require('/makeup-key-emitter$0.0.3/index'/*'makeup-key-emitter'*/);
 var ExitEmitter = require('/makeup-exit-emitter$0.0.4/index'/*'makeup-exit-emitter'*/);
 var dataSetKey = 'data-makeup-index';
@@ -490,11 +490,11 @@ var LinearNavigationModel = function (_NavigationModel) {
             return this._index;
         },
         set: function set(newIndex) {
-            if (newIndex !== this.index) {
+            if (newIndex > -1 && newIndex < this.items.length && newIndex !== this.index) {
                 this._el.dispatchEvent(new CustomEvent('navigationModelChange', {
                     detail: {
-                        toIndex: newIndex,
-                        fromIndex: this.index
+                        fromIndex: this.index,
+                        toIndex: newIndex
                     },
                     bubbles: false
                 }));
@@ -594,8 +594,13 @@ function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
 }
 
+function querySelectorAllToArray(selector, parentNode) {
+    parentNode = parentNode || document;
+    return nodeListToArray(parentNode.querySelectorAll(selector));
+}
+
 module.exports = {
-    nodeListToArray: nodeListToArray
+    querySelectorAllToArray: querySelectorAllToArray
 };
 
 });
@@ -611,7 +616,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var NavigationEmitter = require('/makeup-navigation-emitter$0.1.3/index'/*'makeup-navigation-emitter'*/);
+var NavigationEmitter = require('/makeup-navigation-emitter$0.1.4/index'/*'makeup-navigation-emitter'*/);
 var Util = require('/makeup-roving-tabindex$0.1.2/util'/*'./util.js'*/);
 
 var defaultOptions = {
@@ -624,37 +629,38 @@ function onModelMutation() {
     var modelIndex = this._navigationEmitter.model.index;
 
     this._items.forEach(function (el, index) {
-        if (index !== modelIndex) {
-            el.setAttribute('tabindex', '-1');
-        } else {
-            el.setAttribute('tabindex', '0');
-        }
+        return el.setAttribute('tabindex', index !== modelIndex ? '-1' : '0');
     });
 }
 
 function onModelInit(e) {
-    this._index = e.detail.toIndex;
+    var items = this._items;
 
-    this._items.forEach(function (el) {
-        el.setAttribute('tabindex', '-1');
+    items.filter(function (el, index) {
+        return index !== e.detail.toIndex;
+    }).forEach(function (el) {
+        return el.setAttribute('tabindex', '-1');
     });
-
-    this._items[e.detail.toIndex].setAttribute('tabindex', '0');
+    items[e.detail.toIndex].setAttribute('tabindex', '0');
 }
 
 function onModelReset(e) {
-    this._index = e.detail.toIndex;
+    var items = this._items;
 
-    this._items.forEach(function (el) {
-        el.setAttribute('tabindex', '-1');
+    items.filter(function (el, index) {
+        return index !== e.detail.toIndex;
+    }).forEach(function (el) {
+        return el.setAttribute('tabindex', '-1');
     });
-
-    this._items[e.detail.toIndex].setAttribute('tabindex', '0');
+    items[e.detail.toIndex].setAttribute('tabindex', '0');
 }
 
 function onModelChange(e) {
-    var fromItem = this._items[e.detail.fromIndex];
-    var toItem = this._items[e.detail.toIndex];
+    console.log(e, e.type);
+    var items = this._items;
+
+    var fromItem = items[e.detail.fromIndex];
+    var toItem = items[e.detail.toIndex];
 
     if (fromItem) {
         fromItem.setAttribute('tabindex', '-1');
@@ -667,8 +673,8 @@ function onModelChange(e) {
 
     this._el.dispatchEvent(new CustomEvent('rovingTabindexChange', {
         detail: {
-            toIndex: e.detail.toIndex,
-            fromIndex: e.detail.fromIndex
+            fromIndex: e.detail.fromIndex,
+            toIndex: e.detail.toIndex
         }
     }));
 }
@@ -728,6 +734,14 @@ var LinearRovingTabindex = function (_RovingTabindex) {
             this._navigationEmitter.destroy();
         }
     }, {
+        key: 'index',
+        get: function get() {
+            return this._navigationEmitter.model.index;
+        },
+        set: function set(newIndex) {
+            this._navigationEmitter.model.index = newIndex;
+        }
+    }, {
         key: 'wrap',
         set: function set(newWrap) {
             this._navigationEmitter.model.options.wrap = newWrap;
@@ -738,7 +752,7 @@ var LinearRovingTabindex = function (_RovingTabindex) {
     }, {
         key: '_items',
         get: function get() {
-            return Util.nodeListToArray(this._el.querySelectorAll(this._itemSelector));
+            return Util.querySelectorAllToArray(this._itemSelector);
         }
     }]);
 

--- a/util.js
+++ b/util.js
@@ -4,6 +4,11 @@ function nodeListToArray(nodeList) {
     return Array.prototype.slice.call(nodeList);
 }
 
+function querySelectorAllToArray(selector, parentNode) {
+    parentNode = parentNode || document;
+    return nodeListToArray(parentNode.querySelectorAll(selector));
+}
+
 module.exports = {
-    nodeListToArray: nodeListToArray
+    querySelectorAllToArray: querySelectorAllToArray
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,6 +1563,7 @@ custom-event-polyfill@^1:
 custom-event-polyfill@~0.3:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/custom-event-polyfill/-/custom-event-polyfill-0.3.0.tgz#99807839be62edb446b645832e0d80ead6fa1888"
+  integrity sha1-mYB4Ob5i7bRGtkWDLg2A6tb6GIg=
 
 custom-event@~1.0.0:
   version "1.0.1"
@@ -3610,10 +3611,10 @@ makeup-key-emitter@~0.0.3:
   dependencies:
     custom-event-polyfill "~0.3"
 
-makeup-navigation-emitter@~0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/makeup-navigation-emitter/-/makeup-navigation-emitter-0.1.3.tgz#c0e28fdca9fa72f31c46e15f58593b6e2acf1607"
-  integrity sha512-Ibf2rskPkgo4ym7tubtjirH4dddOkRHRT3OQ76xxnw6cNYmCTDI4Jcu6ZW7jNUBpa4GSepkUpKhe7J7Dp4pS5g==
+makeup-navigation-emitter@~0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/makeup-navigation-emitter/-/makeup-navigation-emitter-0.1.4.tgz#307045f7c003b34bdca88f99b3d9624bfdbb4b92"
+  integrity sha512-LTryj4QcvNafAZZkw6rS81AmwnzgSfTpbm2VHkoZrc60tzJXXfleenCe9y9wanRDDYcMr4Sf3C4TvGB2is/Z6w==
   dependencies:
     custom-event-polyfill "^1"
     makeup-exit-emitter "~0.0.4"


### PR DESCRIPTION
CoreUI will take this update as part of v2.3.0 for Issue https://github.com/eBay/ebayui-core/issues/606

* Added a getter/setter so that index position of roving tabindex can be set directly
* Updated to latest makeup-navigation-emitter which has index out of bounds check
* Updated test page with ability to directly increment/decrement the roving tabindex
* Caching the call to `this._items` in some event handlers rather than calling it multiple times
* Some refactoring/cleanup towards arrow function syntax

Changes tested in Skin website and MIND Patterns site.

@seangates A quick high level lookover of this would be nice, in terms of the API for the getter/setter ability. That ability was there before, but it was buried away. The getter/setters make it more obvious now.